### PR TITLE
Support `pod install`

### DIFF
--- a/ios/RNDynamicBundle.podspec
+++ b/ios/RNDynamicBundle.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNDynamicBundle
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/mauritsd/react-native-dynamic-bundle"
   s.license      = "MIT"
   s.author       = { "author" => "mauritsdijkstra@gmail.com" }
   s.platform     = :ios, "7.0"


### PR DESCRIPTION
`pod install` will error out unless a homepage is set. Cocoapods are the preferred method from RN 0.60 and forward